### PR TITLE
obudump: fix segfault on exit

### DIFF
--- a/tools/obudump.c
+++ b/tools/obudump.c
@@ -242,6 +242,8 @@ int main(int argc, char *argv[])
     }
 
 end:
-    fclose(ivf);
+    if (ivf)
+        fclose(ivf);
+
     return ret;
 }


### PR DESCRIPTION
"The behaviour of fclose() is undefined if the stream parameter is an illegal pointer..."