### PR TITLE
Fix parsing of read_delta_q syntax elements

### DIFF
--- a/obuparse.c
+++ b/obuparse.c
@@ -434,7 +434,7 @@ static inline int _obp_read_delta_q(_OBPBitReader *br, int32_t *out, OBPError *e
             return ret;
         *out = val;
     } else {
-        *out = 1;
+        *out = 0;
     }
     return 0;
 }


### PR DESCRIPTION
Delta Q parameters are used to determine of the frame is coded lossless. This information is later used to determine whether to read loop filter parameters, and will cause a desync there if incorrect.