### PR TITLE
Makefile/install: remove previously-installed symlink first

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ install-shared: libobuparse$(LIBSUF) install-header
 	@install -d $(PREFIX)/lib
 ifneq ($(SYSTEM),MINGW)
 	@install -v libobuparse$(LIBSUF) $(PREFIX)/lib/libobuparse$(LIBSUF).1
+	@rm -fv $(PREFIX)/lib/libobuparse$(LIBSUF)
 	@ln -sv libobuparse$(LIBSUF).1 $(PREFIX)/lib/libobuparse$(LIBSUF)
 else
 	@install -d $(PREFIX)/bin


### PR DESCRIPTION
Causes an error to be thrown on install if the symlink already exists.

While it's a minor thing for a regular make install and the error message lets the user know that the symlink already exists, it causes checkinstall (and possibly other package creation install systems) to break and it won't update the package.