### PR TITLE
Makefile/install: allow prefix to be set as an environment variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PREFIX=/usr/local
+PREFIX ?= /usr/local
 
 CFLAGS  := -O3 -std=c99 -Wall -Wextra -g -fPIC -I. $(CPPFLAGS)
 LDFLAGS +=


### PR DESCRIPTION
Pretty standard, don't force the prefix to `/usr/local` if it's already set in the user's environment.